### PR TITLE
Compatability with ggplot2 3.6.0

### DIFF
--- a/tests/testthat/test-ggm.R
+++ b/tests/testthat/test-ggm.R
@@ -60,7 +60,13 @@ test_that("theming works", {
 		mode = NULL
 	)
 
-	expect_equal(g$labels$x, "sample")
+	labels <- if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+		ggplot2::get_labs(g)
+	} else {
+		g$labels
+	}
+
+	expect_equal(labels$x, "sample")
 	expect_length(g$theme, 0)
 
 	dark <- ggm(


### PR DESCRIPTION
Hi there,

Apologies for not posting an issue first.
The ggplot2 package is planning an update for around May 2025 and a reverse dependency test identified a problem with the EGM package.
The details are explained in https://github.com/tidyverse/ggplot2/issues/6290, but essentially ggplot2 doesn't populate the `plot$labels` field before plot building anymore, which violates some test assumptions in this package.

This PR changes a test to be compatible with both versions of ggplot2. 
You can test the change yourself with the development version of ggplot2 (`pak::pak("tidyverse/ggplot2")`)

Best,
Teun