### PR TITLE
Improve annotation writing channel handling

### DIFF
--- a/tests/testthat/test-wfdb-annotation.R
+++ b/tests/testthat/test-wfdb-annotation.R
@@ -35,3 +35,53 @@ test_that("can read in faulty signal safely", {
   expect_length(ann, 6)
   expect_equal(nrow(ann), 0)
 })
+
+test_that("native annotation write is lossless", {
+  record <- "300"
+  annotator <- "ecgpuwave"
+  record_dir <- test_path()
+  tmp_dir <- withr::local_tempdir()
+
+  ann <- read_annotation(
+    record = record,
+    record_dir = record_dir,
+    annotator = annotator,
+    backend = "native"
+  )
+
+  fs::file_copy(
+    fs::path(record_dir, paste0(record, ".hea")),
+    fs::path(tmp_dir, paste0(record, ".hea"))
+  )
+
+  write_annotation(
+    data = ann,
+    annotator = annotator,
+    record = record,
+    record_dir = tmp_dir,
+    backend = "native",
+    overwrite = TRUE
+  )
+
+  roundtrip <- read_annotation(
+    record = record,
+    record_dir = tmp_dir,
+    annotator = annotator,
+    backend = "native"
+  )
+
+  expect_equal(roundtrip, ann)
+
+  original_path <- fs::path(record_dir, paste0(record, ".", annotator))
+  new_path <- fs::path(tmp_dir, paste0(record, ".", annotator))
+
+  expect_true(fs::file_exists(new_path))
+
+  original_size <- as.integer(fs::file_size(original_path))
+  new_size <- as.integer(fs::file_size(new_path))
+  expect_equal(new_size, original_size)
+
+  original_raw <- readBin(original_path, what = "raw", n = original_size)
+  new_raw <- readBin(new_path, what = "raw", n = new_size)
+  expect_equal(new_raw, original_raw)
+})

--- a/tests/testthat/test-wfdb-native.R
+++ b/tests/testthat/test-wfdb-native.R
@@ -250,6 +250,35 @@ test_that("annotation channels align to header labels", {
   expect_true(all(known_channels %in% header_labels))
 })
 
+test_that("write_annotation emits channel update messages", {
+  record <- "300"
+  record_dir <- test_path()
+  header <- read_header(record, record_dir)
+  header$label <- paste0(header$label, "1")
+
+  ann <- read_annotation(
+    record = record,
+    record_dir = record_dir,
+    annotator = "ecgpuwave",
+    backend = "native"
+  )
+
+  tmp <- withr::local_tempdir()
+
+  expect_message(
+    write_annotation(
+      data = ann,
+      annotator = "ecgpuwave",
+      record = record,
+      record_dir = tmp,
+      backend = "native",
+      overwrite = TRUE,
+      header = header
+    ),
+    "Annotation channel labels were updated"
+  )
+})
+
 
 test_that("can read in annotations natively with faulty signal safely", {
   # Bad ECG that has no signal


### PR DESCRIPTION
## Summary
- add a shared resolver for annotation channel labels and update annotation_table_to_lines to format columns explicitly and retain auxiliary text
- update the system and native annotation writers to align channel names with header labels, propagate auxiliary data, and surface user-facing messages when relabeling occurs
- add regression tests covering native round-trip writes and warning emission when header labels change

## Testing
- Not run (Rscript unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68f14ab2c1688329b6d63917367da71d