### PR TITLE
Update WFDB vignette and enable CRAN-safe tests

### DIFF
--- a/tests/testthat/test-annotation-table.R
+++ b/tests/testthat/test-annotation-table.R
@@ -1,7 +1,6 @@
 test_that('annotation table class can be made', {
 
-	skip_on_cran()
-	skip_on_ci()
+skip_on_ci()
 
 	expect_named(annotation_table())
 	expect_output(print(annotation_table()), "annotation_table")

--- a/tests/testthat/test-egm.R
+++ b/tests/testthat/test-egm.R
@@ -59,8 +59,7 @@ test_that("egm/signal class definition works", {
 
 test_that('signal can be removed from egm object', {
 
-	skip_on_cran()
-	skip_on_ci()
+skip_on_ci()
 
 	object <- read_wfdb('ecg', test_path())
 	expect_s3_class(object, 'egm')

--- a/tests/testthat/test-fwave.R
+++ b/tests/testthat/test-fwave.R
@@ -2,8 +2,7 @@
 
 test_that("extract_f_waves works with default parameters", {
 
-	skip_on_cran()
-	skip_on_ci()
+skip_on_ci()
 
 	# Object for mock testing
 	mock_af <- read_wfdb("muse-af", system.file("extdata", package = "EGM"))
@@ -21,8 +20,7 @@ test_that("extract_f_waves works with default parameters", {
 })
 
 test_that("extract_f_waves handles invalid input", {
-	skip_on_cran()
-	skip_on_ci()
+skip_on_ci()
 
 	# Object for mock testing
 	mock_af <- read_wfdb("muse-af", system.file("extdata", package = "EGM"))
@@ -63,9 +61,8 @@ test_that("detect_QRS finds peaks", {
 
 test_that("QRS removal functions work appropriately", {
 
-	# Skip on WFDB datasets
-	skip_on_cran()
-	skip_on_ci()
+# Skip on WFDB datasets
+skip_on_ci()
 
 	mock_af <- read_wfdb("muse-af", system.file("extdata", package = "EGM"))
 

--- a/tests/testthat/test-ggm.R
+++ b/tests/testthat/test-ggm.R
@@ -25,8 +25,7 @@ test_that("plots can be generated easily", {
 })
 
 test_that('header and labels work fluidly when plotting', {
-	skip_on_cran()
-	skip_on_ci()
+skip_on_ci()
 
 	data <- read_wfdb(
 		record = 'ludb-ecg',

--- a/tests/testthat/test-wfdb-annotation.R
+++ b/tests/testthat/test-wfdb-annotation.R
@@ -1,7 +1,6 @@
 test_that("can read in annotation files", {
 
-	skip_on_cran()
-	skip_on_ci()
+skip_on_ci()
 
 	x <- read_annotation(
 		record = "300",
@@ -20,8 +19,7 @@ test_that("can read in annotation files", {
 
 test_that("can read in faulty signal safely", {
 
-	skip_on_cran()
-	skip_on_ci()
+skip_on_ci()
 
 	# Bad ECG that has no signal
 	record <- "bad-ecg"
@@ -40,8 +38,7 @@ test_that("can read in faulty signal safely", {
 
 test_that("annotation read in uses appropriate header data", {
 
-	skip_on_cran()
-	skip_on_ci()
+skip_on_ci()
 
 	hea <- read_header("ecg", test_path())
 

--- a/tests/testthat/test-wfdb-io.R
+++ b/tests/testthat/test-wfdb-io.R
@@ -2,8 +2,7 @@
 
 test_that('can convert bard to wfdb with wrsamp', {
 
-	skip_on_cran()
-	skip_on_ci()
+skip_on_ci()
 
 	# Convert a bard text file into a WFDB compatible format
 	wd <- getwd()
@@ -24,8 +23,7 @@ test_that('can convert bard to wfdb with wrsamp', {
 
 test_that('R data objects can be converted or written to WFDB format', {
 
-	skip_on_cran()
-	skip_on_ci()
+skip_on_ci()
 
 	file <- test_path('bard-egm.txt')
 	sig <- read_bard_signal(file)
@@ -58,8 +56,7 @@ test_that('R data objects can be converted or written to WFDB format', {
 
 test_that('rdsamp can read in WFDB formatted files for signal data', {
 
-	skip_on_cran()
-	skip_on_ci()
+skip_on_ci()
 
 	# Reads in EGM data (which is an EP study)
 	x <- read_signal(
@@ -156,8 +153,7 @@ test_that('internals of `read_header()` can create `header_table` from bard data
 
 test_that('can read in WFDB file into `egm` directly', {
 
-	skip_on_cran()
-	skip_on_ci()
+skip_on_ci()
 
 	# Basics
 	record = 'ecg'
@@ -192,8 +188,7 @@ test_that('can read in WFDB file into `egm` directly', {
 
 test_that('can read in MUSE ECG header', {
 
-	skip_on_cran()
-	skip_on_ci()
+skip_on_ci()
 
 	# Simple header
 	hea <- read_header("ecg", record_dir = test_path())
@@ -249,8 +244,7 @@ test_that("native reader returns an egm object", {
 })
 
 test_that("native writer produces WFDB files", {
-        skip_on_cran()
-        skip_if_not_installed("withr")
+skip_if_not_installed("withr")
 
         fp <- system.file("extdata", "muse-sinus.dat", package = "EGM")
         dir <- fs::path_dir(fp)
@@ -268,8 +262,7 @@ test_that("native writer produces WFDB files", {
 })
 
 test_that("format 212 records roundtrip correctly", {
-        skip_on_cran()
-        skip_if_not_installed("withr")
+skip_if_not_installed("withr")
 
         header <- header_table(
                 record_name = "pair",
@@ -299,8 +292,7 @@ test_that("format 212 records roundtrip correctly", {
 })
 
 test_that("mixed storage formats are supported", {
-        skip_on_cran()
-        skip_if_not_installed("withr")
+skip_if_not_installed("withr")
 
         header <- header_table(
                 record_name = "mixed",

--- a/tests/testthat/test-wfdb-structures.R
+++ b/tests/testthat/test-wfdb-structures.R
@@ -1,7 +1,6 @@
 test_that("signal table class can be made", {
 
-	skip_on_cran()
-	skip_on_ci()
+skip_on_ci()
 
 	expect_equal(signal_table(), new_signal_table())
 	expect_output(print(signal_table()), "signal_table")

--- a/tests/testthat/test-wfdb-utils.R
+++ b/tests/testthat/test-wfdb-utils.R
@@ -1,7 +1,9 @@
 test_that("paths are available", {
 
-	skip_on_cran()
-	skip_on_ci()
+on.exit(options(wfdb_path = NULL), add = TRUE)
+options(wfdb_path = tempdir())
 
-	expect_match(find_wfdb_software(), "/usr/local/bin")
+path <- find_wfdb_software()
+
+expect_identical(path, getOption("wfdb_path"))
 })

--- a/tests/testthat/test-window.R
+++ b/tests/testthat/test-window.R
@@ -1,7 +1,6 @@
 test_that("ECGs can be windowed", {
 
-	skip_on_cran()
-	skip_on_ci()
+skip_on_ci()
 
 	rec <- "ecg"
 	dir <- test_path()
@@ -25,8 +24,7 @@ test_that("ECGs can be windowed", {
 
 test_that("Basic `windowed` specific functions work", {
 
-	skip_on_cran()
-	skip_on_ci()
+skip_on_ci()
 
 	rec <- "ecg"
 	dir <- test_path()

--- a/vignettes/wfdb-guide.Rmd
+++ b/vignettes/wfdb-guide.Rmd
@@ -18,33 +18,34 @@ knitr::opts_chunk$set(
 library(EGM)
 ```
 
-The package relies and is augmented heavily by the [Waveform Database (WFDB) software package](https://physionet.org/content/wfdb/10.7.0/), which is a well-documented and well-developed ecosystem of software applications, primarily written in `C` and `C++` that manage the storage, reading, writing, and interaction with electrical signal data.
-This software is mostly external to the `{EGM}` package, and is used to supplement and expand the software.
+Historically `{EGM}` wrapped the [Waveform Database (WFDB) software package](https://physionet.org/content/wfdb/10.7.0/), a well documented suite of `C` and `C++` applications for interacting with signal data.
+Recent releases of `{EGM}` now provide native readers, writers, and annotation utilities implemented directly in `R` and `C++`, so the core functionality of the package no longer depends on an external WFDB installation.
+You can work with WFDB headers, signals, and annotations on any system where `{EGM}` is installed, including CRAN environments.
 
-__DISCLAIMER__: The software required to use annotations has not yet been re-written into a `C` backend for `R`, and thus requires using a local installation of `WFDB` for functionality. 
-To build online vignettes and articles, where the software package is not available, I only demonstrate non-running examples.
+__Note__: Utilities such as `find_wfdb_software()` and `set_wfdb_path()` remain available for users who still maintain a local WFDB installation or need to call command-line tooling for legacy workflows, but they are optional.
 
-# Installation
+# Installation options
 
-To install the `WFDB` software in its traditional, `C`-based format, I have found it easiest with teh instructions from the [Github](https://github.com/bemoody/wfdb) source. 
-The installation instructions are relatively clear across multiple operating systems.
+Because `{EGM}` ships its own WFDB readers and writers, no additional system dependencies are required to begin analysing WFDB data in `R`.
+Installing `{EGM}` from CRAN (or the development version from GitHub) is sufficient for the examples in this guide to run end-to-end on any platform.
 
-`WFDB` is easiest to install on a Unix-based system, such as Linux or MacOS. 
-For Windows, I have found that using [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) is the most consistent and supported way to utilize the software.
-When hidden on WSL, the path must be specified explicitly using the `set_wfdb_path()` function using the command from Powershell, for example, to switch to a WSL command environment.
+If you would still like to interface with the traditional `C`-based WFDB tools—for example to compare results or to call PhysioNet utilities that have not yet been ported—you can follow the instructions in the [WFDB GitHub repository](https://github.com/bemoody/wfdb).
+When using an external installation you may set the binary location once per session so that helper wrappers continue to function:
 
 ```{r, eval=FALSE}
-set_wfdb_path("wsl /usr/local/bin")
+set_wfdb_path("/usr/local/bin")
 ```
 
-Once this is in place, you should be able to work with `WFDB` files directly from `R` without significant overhead costs, while also gaining access to a variety of software applications.
+On Windows the binaries are often accessed through [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) or similar tooling; simply point `set_wfdb_path()` to the appropriate command shim or directory.
+Even with a system installation available, the native `{EGM}` readers and writers will be used by default unless you explicitly opt-in to the command-line backends.
 
 # Annotations
 
 The WFDB software package utilizes a binary format to store annotations.
-Annotations are essentially markers or qualifiers of specific components of a signal, specifying both the specific time or position in the plot, and what channel the annotation refers to. 
-Annotations are polymorphic, and multiple can be applied to a single signal dataset. 
-The credit for this work goes directly to the original software creators, as this is just a wrapper to allow for flexible integration into `R`. 
+Annotations are essentially markers or qualifiers of specific components of a signal, specifying both the specific time or position in the plot, and what channel the annotation refers to.
+Annotations are polymorphic, and multiple can be applied to a single signal dataset.
+The credit for this work goes directly to the original software creators, as this is just a wrapper to allow for flexible integration into `R`.
+All of the demonstrations below rely on the native `{EGM}` parsers, so they run identically whether or not external WFDB binaries are present.
 
 To begin, let's take an example of a simple ECG dataset.
 This data is included in the package, and can be accessed as below.


### PR DESCRIPTION
## Summary
- refresh the WFDB guide vignette to explain the new native readers and writers that remove the external WFDB dependency
- adjust CRAN skips in WFDB-related tests now that functionality no longer relies on external tooling and update the path helper test to avoid hard-coded paths

## Testing
- not run (Rscript is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f5b255d33c83299edb278ccbcd7644