### PR TITLE
Fix WFDB fidelity issues in signal and annotation I/O

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,21 @@
+# EGM (development version)
+
+* **WFDB fidelity fixes** in the native C++ reader/writer:
+    * Fixed a format 8 (8-bit first difference) round-trip bug where the writer
+      primed its difference accumulator at 0 while the reader primed it at the
+      header initial value, causing sample 0 to be double-counted on read-back.
+    * Annotation `chan` and `num` fields are now treated as *persistent* (they
+      carry forward to subsequent annotations until changed), matching the WFDB
+      specification; `subtype` and `aux` remain per-annotation. This fixes
+      reading of standard WFDB annotation files that record these fields only
+      when they change. The writer now emits `chan`/`num` records only on change.
+    * `write_wfdb()` now computes the WFDB signal checksum from the data being
+      written, so files validate cleanly with standard WFDB tools (e.g. `rdsamp`).
+    * Fixed missing-value (`NA`) detection for the ADC gain, which previously
+      used an equality comparison against `NA_REAL` (always false for a NaN).
+* Added regression tests for format 8/80 round-trips, checksum computation, and
+  persistent annotation field handling.
+
 # EGM 0.2.0
 
 This release includes major improvements to WFDB functionality and package structure.

--- a/src/wfdb.cpp
+++ b/src/wfdb.cpp
@@ -795,7 +795,7 @@ cpp11::writable::list read_signal_native_cpp(const std::string &data_path,
                                                         value -= static_cast<double>(baseline_value);
                                                 }
                                                 double gain_value = adc_gain[channel_idx];
-                                                if (gain_value != NA_REAL && gain_value != 0.0) {
+                                                if (!is_na(gain_value) && gain_value != 0.0) {
                                                         value /= gain_value;
                                                 }
                                         }
@@ -812,7 +812,7 @@ cpp11::writable::list read_signal_native_cpp(const std::string &data_path,
                                                         value -= static_cast<double>(baseline_value);
                                                 }
                                                 double gain_value = adc_gain[channel_idx + 1];
-                                                if (gain_value != NA_REAL && gain_value != 0.0) {
+                                                if (!is_na(gain_value) && gain_value != 0.0) {
                                                         value /= gain_value;
                                                 }
                                         }
@@ -865,7 +865,7 @@ cpp11::writable::list read_signal_native_cpp(const std::string &data_path,
                                                 value -= static_cast<double>(baseline_value);
                                         }
                                         double gain_value = adc_gain[channel_idx];
-                                        if (gain_value != NA_REAL && gain_value != 0.0) {
+                                        if (!is_na(gain_value) && gain_value != 0.0) {
                                                 value /= gain_value;
                                         }
                                 }
@@ -968,6 +968,14 @@ void write_wfdb_native_cpp(const std::string &data_path,
         // Track initial_value per channel for the header (first digital sample)
         std::vector<int32_t> computed_initial(number_of_channels, 0);
 
+        // WFDB stores a 16-bit checksum for every signal: the running sum of
+        // all of that signal's digitised samples.  We accumulate it here (in a
+        // 64-bit integer to avoid overflow) and truncate to 16 bits when the
+        // header is written.  Computing it from the data we actually write
+        // means standard WFDB tools (e.g. rdsamp) will not report a checksum
+        // error after a round trip.
+        std::vector<long long> checksum_accum(number_of_channels, 0);
+
         for (int i = 0; i < samples; ++i) {
                 for (int channel_idx = 0; channel_idx < number_of_channels; ++channel_idx) {
                         // Extract value from either integer or double matrix
@@ -985,7 +993,7 @@ void write_wfdb_native_cpp(const std::string &data_path,
                         if (physical) {
                                 double gain_value = adc_gain[channel_idx];
                                 int baseline_value = adc_baseline[channel_idx];
-                                if (gain_value != NA_REAL && gain_value != 0.0) {
+                                if (!is_na(gain_value) && gain_value != 0.0) {
                                         value *= gain_value;
                                 }
                                 if (baseline_value != NA_INTEGER) {
@@ -1057,9 +1065,24 @@ void write_wfdb_native_cpp(const std::string &data_path,
                         }
                         digital_row[channel_idx] = static_cast<int32_t>(scaled);
 
-                        // Record initial value from first sample
+                        // Accumulate the per-signal checksum from the digital
+                        // value, exactly as the WFDB specification defines it.
+                        checksum_accum[channel_idx] += scaled;
+
+                        // Record initial value from first sample.
                         if (i == 0) {
                                 computed_initial[channel_idx] = static_cast<int32_t>(scaled);
+                                // For format 8 (first differences) prime the
+                                // "previous value" accumulator with the first
+                                // sample so the first difference written is 0.
+                                // On read-back sample 0 is recovered as
+                                // (initial_value + 0); priming with 0 instead
+                                // would make the reader double-count the initial
+                                // value (see read_signal_native_cpp, where the
+                                // accumulator starts at initial_value).
+                                if (fmt == 8) {
+                                        fmt8_prev[channel_idx] = static_cast<int32_t>(scaled);
+                                }
                         }
                 }
 
@@ -1144,7 +1167,11 @@ void write_wfdb_native_cpp(const std::string &data_path,
         for (int channel_idx = 0; channel_idx < number_of_channels; ++channel_idx) {
                 std::string adc_spec;
                 double gain_value = adc_gain[channel_idx];
-                if (gain_value == NA_REAL) {
+                // NOTE: an R NA is represented as a special NaN, so it must be
+                // tested with is_na() -- a plain `gain_value == NA_REAL` is
+                // always false because NaN never compares equal to anything.
+                // 200 is the WFDB default gain when none is recorded.
+                if (is_na(gain_value)) {
                         gain_value = 200.0;
                 }
                 int baseline_value = adc_baseline[channel_idx];
@@ -1175,10 +1202,15 @@ void write_wfdb_native_cpp(const std::string &data_path,
                 // to ensure the header accurately reflects the written data.
                 int initial = computed_initial[channel_idx];
 
-                int checksum_value = checksum[channel_idx];
-                if (checksum_value == NA_INTEGER) {
-                        checksum_value = 0;
-                }
+                // Prefer the checksum we computed from the data we just wrote
+                // over any value carried in from the header.  The WFDB checksum
+                // is the sum of all of a signal's samples, truncated to 16 bits
+                // and interpreted as a signed value (hence it may be negative).
+                // The incoming `checksum` argument is retained for API
+                // compatibility but is intentionally not trusted here, because
+                // the signal may have been edited since the header was read.
+                int checksum_value = static_cast<int>(static_cast<int16_t>(
+                        static_cast<uint16_t>(checksum_accum[channel_idx] & 0xFFFFLL)));
                 int blocksize_value = blocksize[channel_idx];
                 if (blocksize_value == NA_INTEGER) {
                         blocksize_value = 0;
@@ -1236,10 +1268,19 @@ cpp11::writable::list read_annotation_native_cpp(const std::string &annotation_p
         // Special codes (59-63) mutate state rather than producing actual
         // annotations, so the logic below resembles a small state machine.
         //
-        // Per WFDB CLI behaviour (rdann/wrann), modifier records (60-63)
-        // apply to the most recently emitted annotation, not a future one.
-        // We still keep a fallback path for malformed streams that place
-        // modifiers before the first annotation.
+        // Per the WFDB specification (and the rdann/wrann tools), modifier
+        // records (60-63) follow the annotation they qualify and apply to the
+        // most recently emitted annotation.  Two of these fields behave
+        // differently from the other two:
+        //
+        //   * `chan` (CHN, code 62) and `num` (NUM, code 60) are PERSISTENT:
+        //     once set they remain in effect for every following annotation
+        //     until explicitly changed again.  This is why WFDB files only
+        //     store them when they change.
+        //
+        //   * `subtype` (SUB, code 61) and `aux` (AUX, code 63) are
+        //     PER-ANNOTATION: they apply only to the single annotation they
+        //     follow and reset to their defaults (0 and "") afterwards.
         std::vector<int> samples;
         std::vector<std::string> types;
         std::vector<int> subtypes;
@@ -1249,17 +1290,18 @@ cpp11::writable::list read_annotation_native_cpp(const std::string &annotation_p
 
         int32_t current_sample = 0;
 
-        // Fallback defaults used only if a malformed stream emits modifiers
-        // before the first actual annotation.
+        // Persistent fields: these carry their value forward to subsequent
+        // annotations until a CHN/NUM record changes them.
         int current_num = 0;
         int current_channel = 0;
 
-        // Transient state for malformed streams that place modifiers before
-        // the annotation they are intended to modify.
+        // Per-annotation state, only used to attach a SUB record to the next
+        // annotation in the rare (technically malformed) case where the
+        // modifier appears before any annotation has been emitted.
         int pending_subtype = 0;
         bool has_pending_subtype = false;
 
-        // Transient state for AUX (applies to next annotation only)
+        // Per-annotation state for AUX, handled the same way as SUB above.
         std::string pending_aux;
         bool has_pending_aux = false;
 
@@ -1287,19 +1329,20 @@ cpp11::writable::list read_annotation_native_cpp(const std::string &annotation_p
                 }
 
                 if (code == 60) {
-                        // NUM: modify previous annotation; if none exists yet,
-                        // keep as fallback for the first annotation.
+                        // NUM (persistent): update the running value and the
+                        // annotation it follows.  The new value also becomes
+                        // the default for every subsequent annotation.
+                        current_num = interval;
                         if (!numbers.empty()) {
                                 numbers.back() = interval;
-                        } else {
-                                current_num = interval;
                         }
                         continue;
                 }
 
                 if (code == 61) {
-                        // SUB: modify previous annotation; if none exists yet,
-                        // keep as fallback for the first annotation.
+                        // SUB (per-annotation): apply only to the previous
+                        // annotation.  If none exists yet, stash it for the
+                        // next one (handles technically malformed streams).
                         if (!subtypes.empty()) {
                                 subtypes.back() = interval;
                         } else {
@@ -1310,20 +1353,20 @@ cpp11::writable::list read_annotation_native_cpp(const std::string &annotation_p
                 }
 
                 if (code == 62) {
-                        // CHN: modify previous annotation; if none exists yet,
-                        // keep as fallback for the first annotation.
+                        // CHN (persistent): update the running value and the
+                        // annotation it follows; it carries forward thereafter.
+                        current_channel = interval;
                         if (!channels.empty()) {
                                 channels.back() = interval;
-                        } else {
-                                current_channel = interval;
                         }
                         continue;
                 }
 
                 if (code == 63) {
                         std::string aux_value = read_auxiliary(stream, interval);
-                        // AUX: modify previous annotation; if none exists yet,
-                        // keep as fallback for the first annotation.
+                        // AUX (per-annotation): apply only to the previous
+                        // annotation, or stash it for the next one if none
+                        // has been emitted yet.
                         if (!auxdata.empty()) {
                                 auxdata.back() = aux_value;
                         } else {
@@ -1336,13 +1379,11 @@ cpp11::writable::list read_annotation_native_cpp(const std::string &annotation_p
                 current_sample += interval;
                 std::string symbol = annotation_symbol(code);
 
-                // SUB applies to this annotation only, then resets
+                // SUB and AUX apply to this annotation only.  CHN and NUM use
+                // the persistent running values, which are NOT reset below.
                 int subtype_value = has_pending_subtype ? pending_subtype : 0;
-                // NUM and CHN are only used for malformed files where modifiers
-                // appeared before the first annotation.
                 int channel_value = current_channel;
                 int num_value = current_num;
-                // AUX applies to this annotation only
                 std::string aux_value = has_pending_aux ? pending_aux : "";
 
                 samples.push_back(current_sample);
@@ -1352,13 +1393,11 @@ cpp11::writable::list read_annotation_native_cpp(const std::string &annotation_p
                 numbers.push_back(num_value);
                 auxdata.push_back(aux_value);
 
-                // Reset transient state only
+                // Reset the per-annotation transient state only; the persistent
+                // current_num / current_channel deliberately carry forward.
                 has_pending_subtype = false;
                 has_pending_aux = false;
                 pending_aux.clear();
-                // Reset fallback defaults after first use.
-                current_num = 0;
-                current_channel = 0;
         }
 
         size_t n = samples.size();
@@ -1410,6 +1449,11 @@ void write_annotation_native_cpp(const std::string &annotation_path,
         }
 
         int prev_sample = 0;
+        // Track the most recently written persistent fields so we only emit a
+        // CHN/NUM record when the value actually changes (WFDB semantics).
+        // Both start at 0, the WFDB default for the first annotation.
+        int prev_chan = 0;
+        int prev_num = 0;
 
         auto get_value = [](const cpp11::integers &vec, int index) {
                 if (index >= vec.size()) {
@@ -1459,6 +1503,10 @@ void write_annotation_native_cpp(const std::string &annotation_path,
                 write_annotation_pair(stream, code, interval);
 
                 // Write modifier codes AFTER the annotation pair.
+
+                // SUB (subtype) is per-annotation: emit it whenever this
+                // annotation carries a non-zero subtype.  It does not persist,
+                // so there is no need to "reset" it for the next annotation.
                 int subtype_value = get_value(subtypes, i);
                 if (subtype_value < 0 || subtype_value > 1023) {
                         stop("Annotation subtype must be between 0 and 1023");
@@ -1467,20 +1515,27 @@ void write_annotation_native_cpp(const std::string &annotation_path,
                         write_annotation_pair(stream, 61, subtype_value);
                 }
 
+                // CHN (channel) is persistent: only emit a record when the
+                // value differs from the previous annotation.  Emitting on a
+                // change back to 0 is required so the reader stops carrying the
+                // old channel forward.
                 int channel_value = get_value(channels, i);
                 if (channel_value < 0 || channel_value > 1023) {
                         stop("Annotation channel must be between 0 and 1023");
                 }
-                if (channel_value != 0) {
+                if (channel_value != prev_chan) {
                         write_annotation_pair(stream, 62, channel_value);
+                        prev_chan = channel_value;
                 }
 
+                // NUM is persistent, handled exactly like CHN above.
                 int num_value = get_value(numbers, i);
                 if (num_value < 0 || num_value > 1023) {
                         stop("Annotation number must be between 0 and 1023");
                 }
-                if (num_value != 0) {
+                if (num_value != prev_num) {
                         write_annotation_pair(stream, 60, num_value);
+                        prev_num = num_value;
                 }
 
                 // Write AUX data if present.

--- a/tests/testthat/test-wfdb-io.R
+++ b/tests/testthat/test-wfdb-io.R
@@ -198,6 +198,102 @@ test_that("mixed storage formats are supported", {
   expect_equal(roundtrip$CH32, signal$CH32)
 })
 
+test_that("format 8 first-difference records roundtrip correctly", {
+  skip_if_not_installed("withr")
+
+  # Format 8 stores 8-bit first differences, so successive samples must stay
+  # within +/-127 of each other.  This guards against the regression where the
+  # writer primed the difference accumulator at 0 while the reader primed it at
+  # the header initial value, double-counting sample 0 on read-back.
+  header <- header_table(
+    record_name = "diff8",
+    number_of_channels = 1L,
+    frequency = 360,
+    samples = 6L,
+    storage_format = 8L,
+    ADC_gain = 200,
+    ADC_baseline = 0L,
+    ADC_units = "mV",
+    label = "II"
+  )
+
+  signal <- signal_table(data.table::data.table(
+    sample = 0:5,
+    II = c(500L, 505L, 498L, 520L, 510L, 511L)
+  ))
+
+  tmp <- withr::local_tempdir()
+  write_wfdb(signal, record = "diff8", record_dir = tmp, header = header)
+
+  roundtrip <- read_signal("diff8", tmp, units = "digital")
+  expect_equal(roundtrip$II, signal$II)
+})
+
+test_that("format 80 offset-binary records roundtrip correctly", {
+  skip_if_not_installed("withr")
+
+  header <- header_table(
+    record_name = "off80",
+    number_of_channels = 1L,
+    frequency = 250,
+    samples = 5L,
+    storage_format = 80L,
+    ADC_gain = 200,
+    ADC_baseline = 0L,
+    ADC_units = "mV",
+    label = "II"
+  )
+
+  # Format 80 holds a signed value in the range [-128, 127].
+  signal <- signal_table(data.table::data.table(
+    sample = 0:4,
+    II = c(-128L, -1L, 0L, 1L, 127L)
+  ))
+
+  tmp <- withr::local_tempdir()
+  write_wfdb(signal, record = "off80", record_dir = tmp, header = header)
+
+  roundtrip <- read_signal("off80", tmp, units = "digital")
+  expect_equal(roundtrip$II, signal$II)
+})
+
+test_that("write_wfdb computes a correct WFDB signal checksum", {
+  skip_if_not_installed("withr")
+
+  header <- header_table(
+    record_name = "cksum",
+    number_of_channels = 1L,
+    frequency = 250,
+    samples = 4L,
+    storage_format = 16L,
+    ADC_gain = 200,
+    ADC_baseline = 0L,
+    ADC_units = "mV",
+    label = "II"
+  )
+
+  samples <- c(30000L, 30000L, 30000L, 1000L)
+  signal <- signal_table(data.table::data.table(
+    sample = 0:3,
+    II = samples
+  ))
+
+  tmp <- withr::local_tempdir()
+  write_wfdb(signal, record = "cksum", record_dir = tmp, header = header)
+
+  # The WFDB checksum is the sum of all digital samples, truncated to 16 bits
+  # and interpreted as a signed value (so it may be negative).
+  raw <- sum(as.numeric(samples)) %% 65536
+  expected <- ifelse(raw >= 32768, raw - 65536, raw)
+
+  hea_lines <- readLines(fs::path(tmp, "cksum", ext = "hea"))
+  signal_line <- hea_lines[2]
+  fields <- strsplit(trimws(signal_line), "[[:space:]]+")[[1]]
+  written_checksum <- as.integer(fields[7]) # 7th field is the checksum
+
+  expect_equal(written_checksum, as.integer(expected))
+})
+
 # Native annotation ---------------------------------------------------------
 
 test_that("read_annotation parses annotations", {
@@ -247,6 +343,43 @@ test_that("read_annotation respects begin and end windows", {
   } else {
     succeed()
   }
+})
+
+test_that("reading carries persistent channel/number forward (WFDB semantics)", {
+  skip_if_not_installed("withr")
+  tmp <- withr::local_tempdir()
+
+  # Hand-build a raw annotation stream that sets the channel exactly ONCE,
+  # which is how standard WFDB tools (wrann) store a persistent field.  Each
+  # entry is a little-endian 16-bit word: (code << 10) | interval.
+  bytes <- as.raw(c(
+    0x64, 0x04, # "N" beat, interval 100  -> sample 100
+    0x05, 0xF8, # CHN = 5 (code 62); applies to the beat above and persists
+    0x32, 0x04, # "N" beat, interval 50   -> sample 150
+    0x32, 0x04, # "N" beat, interval 50   -> sample 200
+    0x00, 0x00  # terminator
+  ))
+  writeBin(bytes, fs::path(tmp, "persist", ext = "qrs"))
+
+  header <- header_table(
+    record_name = "persist",
+    number_of_channels = 1L,
+    frequency = 360,
+    samples = 1000L,
+    storage_format = 16L,
+    label = "II"
+  )
+
+  ann <- read_annotation(
+    record = "persist",
+    annotator = "qrs",
+    record_dir = tmp,
+    header = header
+  )
+
+  expect_equal(ann$sample, c(100L, 150L, 200L))
+  # The single CHN record must carry forward to every subsequent annotation.
+  expect_equal(ann$channel, c(5L, 5L, 5L))
 })
 
 test_that("write_annotation produces round-trip compatible files", {


### PR DESCRIPTION
## Summary
This PR fixes several fidelity issues in the native C++ WFDB reader/writer to ensure proper round-trip compatibility with standard WFDB tools and correct handling of the WFDB specification.

## Key Changes

* **Format 8 (8-bit first difference) round-trip fix**: The writer now primes the difference accumulator with the first sample value (matching the reader's behavior), preventing double-counting of sample 0 on read-back.

* **Annotation persistent field semantics**: Implemented correct WFDB specification behavior where `chan` (CHN, code 62) and `num` (NUM, code 60) fields are *persistent* (carry forward to subsequent annotations until changed), while `subtype` (SUB, code 61) and `aux` (AUX, code 63) remain per-annotation. The writer now emits CHN/NUM records only when values change.

* **WFDB signal checksum computation**: `write_wfdb()` now computes the checksum from the actual data being written (sum of all digital samples, truncated to 16 bits as a signed value) rather than using the input header value. This ensures files validate cleanly with standard WFDB tools like `rdsamp`.

* **NA detection fix**: Replaced direct equality comparisons against `NA_REAL` with `is_na()` calls for ADC gain validation. Direct comparison always fails since NaN never equals anything, including itself.

## Implementation Details

- Added `checksum_accum` vector to track per-signal checksums during write operations
- Updated annotation reading logic to maintain persistent state for CHN/NUM while handling SUB/AUX as per-annotation modifiers
- Updated annotation writing logic to track previous CHN/NUM values and only emit records on change
- Added comprehensive comments explaining WFDB specification semantics for annotation modifiers
- Added regression tests for format 8/80 round-trips, checksum computation, and persistent annotation field handling

https://claude.ai/code/session_019aJm8nuL3zU34gjZNQWxPN